### PR TITLE
feat: Se agrega un enlace para registrarse si es que el usuario no tiene cuenta

### DIFF
--- a/src/views/loginPage/LoginPage.tsx
+++ b/src/views/loginPage/LoginPage.tsx
@@ -19,6 +19,7 @@ import {useContext, useState } from "react";
 import { User } from "@/interfaces/User";
 import { ResponseAPI } from "@/interfaces/ResponseAPI";
 import { AuthContext } from "@/contexts/AuthContext";
+import Link from "next/link";
 
 const formSchema = z.object({
   email: z
@@ -146,6 +147,12 @@ export const LoginPage = () => {
             >
               INGRESAR
             </Button>
+            <p className="text-center text-sm text-black">
+              ¿No tienes una cuenta? {""}
+              <Link href="/register" className="text-[#1C3873] hover:underline">
+                Registrate
+              </Link>
+            </p>
           </form>
         </Form>
       </div>


### PR DESCRIPTION
### 📌 Título de la PR

`feat: Se agrega un enlace para registrarse si el usuario no tiene cuenta`

---

### 📋 Descripción

Este *pull request* incorpora un enlace en la vista de inicio de sesión que dirige al formulario de registro.  
Está pensado para mejorar la experiencia del usuario, facilitando el acceso al proceso de creación de cuenta para nuevos usuarios.

---

### 🔧 Cambios realizados

- Se añadió un texto o botón con el mensaje: *"¿No tienes cuenta? Regístrate aquí"*
- El enlace redirige correctamente al formulario de registro (`/register`)
- Se aplicaron estilos consistentes con la interfaz existente
- Se aseguró que el enlace sea accesible y visible 

---

### 🧪 Cómo probar

1. Ir a la pantalla de inicio de sesión (`/login`)
2. Verificar que el mensaje o botón de registro se muestra al usuario
3. Al hacer clic, se redirige a la vista de registro
4. Comprobar que no hay errores visuales ni de navegación

---

### 🧱 Consideraciones técnicas

- No se modificó lógica de backend
- El cambio es solo a nivel de interfaz
- Este commit no incluye *breaking changes*
- Sigue la convención `feat` al agregar una nueva funcionalidad visible al usuario
