### PR TITLE
Fix/register service refactor: Se mueve la lógica de register a AuthService para separar responsabilidades.

### DIFF
--- a/src/services/AuthServices.ts
+++ b/src/services/AuthServices.ts
@@ -1,14 +1,39 @@
 import { ApiBackend } from "@/clients/axios";
 import { ResponseAPI } from "@/interfaces/ResponseAPI";
 
+
 interface LoginPayload {
   email: string;
   password: string;
 }
+
+interface RegisterPayload {
+  firtsName: string;
+  lastName: string;
+  email: string;
+  birthDate: string | null;
+  thelephone: string;
+  password: string;
+  confirmPassword: string;
+  street?: string | null;
+  number?: string | null;
+  commune?: string | null;
+  region?: string | null;
+  postalCode?: string | null;
+}
+
 
 export const AuthService = {
   login: async (payload: LoginPayload): Promise<ResponseAPI> => {
     const response = await ApiBackend.post<ResponseAPI>("Auth/login", payload);
     return response.data;
   },
+
+  async register(payload: RegisterPayload) {
+    const response = await ApiBackend.post<ResponseAPI>("Auth/register",payload);
+    return response.data;
+  },
 };
+
+
+

--- a/src/views/registerPage/RegisterPage.tsx
+++ b/src/views/registerPage/RegisterPage.tsx
@@ -14,10 +14,10 @@ import { useForm } from "react-hook-form";
 import { useState } from "react";
 import z from "zod";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { ApiBackend } from "@/clients/axios";
 import { toast } from "sonner";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
+import { AuthService } from "@/services/AuthServices";
 
 const formSchema = z
   .object({
@@ -117,7 +117,7 @@ export const RegisterPage = () => {
 
       console.log("Payload enviado al backend:", payload);
 
-      const { data } = await ApiBackend.post("Auth/register", payload);
+      const data = await AuthService.register(payload);
 
       if (data.success === false) {
         setServerError(data.message || "Error al registrar.");


### PR DESCRIPTION
### 📌 Título de la PR

`refactor(auth): trasladar la lógica de registro a AuthService`

---

### 📋 Descripción

Este *pull request* realiza una refactorización del componente `RegisterPage` para mover la lógica de registro a un nuevo archivo de servicio llamado `AuthService`.

El objetivo es mantener una separación clara entre la lógica de negocio y la lógica de presentación, lo que facilita la escalabilidad y el mantenimiento del código a futuro.

---

### 🔧 Cambios realizados

- Se creó el método `register` en `src/services/AuthService.ts`.
- Se trasladó el llamado a `ApiBackend.post("Auth/register", ...)` desde el componente `RegisterPage` al nuevo servicio.
- Se adaptó el `onSubmit` del formulario para que utilice `AuthService.register`.
- Se mantuvo el feedback visual al usuario ante errores o éxito en el registro.

---

### 🧪 Cómo probar

1. Levantar la aplicación (`npm run dev`).
2. Acceder a la vista de registro (`/register`).
3. Completar el formulario con datos válidos.
4. Verificar que:
   - El registro se realiza correctamente y redirige al login.
   - En caso de error del servidor, se muestra el mensaje correspondiente.
   - La funcionalidad y validaciones del formulario permanecen intactas.